### PR TITLE
Structure all queries

### DIFF
--- a/lib/ecto_psql_extras.ex
+++ b/lib/ecto_psql_extras.ex
@@ -1,69 +1,83 @@
 defmodule EctoPSQLExtras do
-  @queries %{
-    bloat: EctoPSQLExtras.Bloat,
-    blocking: EctoPSQLExtras.Blocking,
-    cache_hit: EctoPSQLExtras.CacheHit,
-    calls: EctoPSQLExtras.Calls,
-    extensions: EctoPSQLExtras.Extensions,
-    table_cache_hit: EctoPSQLExtras.TableCacheHit,
-    index_cache_hit: EctoPSQLExtras.IndexCacheHit,
-    index_size: EctoPSQLExtras.IndexSize,
-    index_usage: EctoPSQLExtras.IndexUsage,
-    locks: EctoPSQLExtras.Locks,
-    all_locks: EctoPSQLExtras.AllLocks,
-    long_running_queries: EctoPSQLExtras.LongRunningQueries,
-    mandelbrot: EctoPSQLExtras.Mandelbrot,
-    outliers: EctoPSQLExtras.Outliers,
-    records_rank: EctoPSQLExtras.RecordsRank,
-    seq_scans: EctoPSQLExtras.SeqScans,
-    table_indexes_size: EctoPSQLExtras.TableIndexesSize,
-    table_size: EctoPSQLExtras.TableSize,
-    total_index_size: EctoPSQLExtras.TotalIndexSize,
-    total_table_size: EctoPSQLExtras.TotalTableSize,
-    unused_indexes: EctoPSQLExtras.UnusedIndexes,
-    vacuum_stats: EctoPSQLExtras.VacuumStats,
-    kill_all: EctoPSQLExtras.KillAll
-  }
+  @moduledoc """
+  The entry point for each function.
+  """
 
+  @callback info :: %{
+              required(:title) => binary,
+              required(:columns) => [%{name: atom, type: atom}],
+              optional(:order_by) => [{atom, :asc | :desc}],
+              optional(:limit) => pos_integer
+            }
+
+  @callback query :: binary
+
+  @doc """
+  Returns all queries and their modules.
+  """
+  def queries do
+    %{
+      bloat: EctoPSQLExtras.Bloat,
+      blocking: EctoPSQLExtras.Blocking,
+      cache_hit: EctoPSQLExtras.CacheHit,
+      calls: EctoPSQLExtras.Calls,
+      extensions: EctoPSQLExtras.Extensions,
+      table_cache_hit: EctoPSQLExtras.TableCacheHit,
+      index_cache_hit: EctoPSQLExtras.IndexCacheHit,
+      index_size: EctoPSQLExtras.IndexSize,
+      index_usage: EctoPSQLExtras.IndexUsage,
+      locks: EctoPSQLExtras.Locks,
+      all_locks: EctoPSQLExtras.AllLocks,
+      long_running_queries: EctoPSQLExtras.LongRunningQueries,
+      mandelbrot: EctoPSQLExtras.Mandelbrot,
+      outliers: EctoPSQLExtras.Outliers,
+      records_rank: EctoPSQLExtras.RecordsRank,
+      seq_scans: EctoPSQLExtras.SeqScans,
+      table_indexes_size: EctoPSQLExtras.TableIndexesSize,
+      table_size: EctoPSQLExtras.TableSize,
+      total_index_size: EctoPSQLExtras.TotalIndexSize,
+      total_table_size: EctoPSQLExtras.TotalTableSize,
+      unused_indexes: EctoPSQLExtras.UnusedIndexes,
+      vacuum_stats: EctoPSQLExtras.VacuumStats,
+      kill_all: EctoPSQLExtras.KillAll
+    }
+  end
+
+  @doc """
+  Run a query with `name`, on `repo`, in the given `format`.
+
+  `format` is either `:ascii` or `:raw`.
+  """
   def query(name, repo, format \\ :ascii) do
-    query_module = @queries[name]
-    result = repo.query(query_module.query) |> elem(1)
+    query_module = queries()[name]
+    result = repo.query!(query_module.query)
+    format(format, query_module.info, result)
+  end
 
-    if format == :ascii do
-      rows = if length(result.rows) == 0 do
+  defp format(:ascii, info, result) do
+    rows =
+      if result.rows == [] do
         [["No results", nil]]
       else
-        Enum.map result.rows, fn n -> parse(n) end
+        Enum.map(result.rows, &parse_row/1)
       end
 
-      TableRex.quick_render!(
-        rows, result.columns, query_module.title
-      ) |> IO.puts
-    end
+    names = Enum.map(info.columns, & &1.name)
 
-    if format == :raw do
-      result
-    end
+    rows
+    |> TableRex.quick_render!(names, info.title)
+    |> IO.puts()
   end
 
-  defp parse(list) do
-    Enum.map list, fn n ->
-      IEx.Info.info(n)
-      |> Enum.at(0)
-      |> elem(1)
-      |> do_parse(n)
-    end
+  defp format(:raw, _info, result) do
+    result
   end
 
-  defp do_parse(elem, n) when elem == "Decimal" do
-    Decimal.to_float n
+  defp parse_row(list) do
+    Enum.map(list, &parse_column/1)
   end
 
-  defp do_parse(elem, n) when elem == "Postgrex.Interval" do
-    inspect n
-  end
-
-  defp do_parse(_,n) do
-    n
-  end
+  defp parse_column(%struct{} = decimal) when struct == Decimal, do: Decimal.to_float(decimal)
+  defp parse_column(binary) when is_binary(binary), do: binary
+  defp parse_column(other), do: inspect(other)
 end

--- a/lib/queries/all_locks.ex
+++ b/lib/queries/all_locks.ex
@@ -1,26 +1,39 @@
 defmodule EctoPSQLExtras.AllLocks do
-  def title do
-    "Queries with active locks"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Queries with active locks",
+      columns: [
+        %{name: :pid, type: :integer},
+        %{name: :relname, type: :string},
+        %{name: :transactionid, type: :integer},
+        %{name: :granted, type: :boolean},
+        %{name: :query_snippet, type: :string},
+        %{name: :mode, type: :string},
+        %{name: :age, type: :interval}
+      ]
+    }
   end
 
   def query do
-"""
-/* Queries with active locks */
+    """
+    /* Queries with active locks */
 
-SELECT
-  pg_stat_activity.pid,
-  pg_class.relname,
-  pg_locks.transactionid,
-  pg_locks.granted,
-  pg_locks.mode,
-  pg_stat_activity.query AS query_snippet,
-  age(now(),pg_stat_activity.query_start) AS "age"
-FROM pg_stat_activity,pg_locks left
-OUTER JOIN pg_class
-  ON (pg_locks.relation = pg_class.oid)
-WHERE pg_stat_activity.query <> '<insufficient privilege>'
-  AND pg_locks.pid = pg_stat_activity.pid
-  AND pg_stat_activity.pid <> pg_backend_pid() order by query_start;
-"""
+    SELECT
+      pg_stat_activity.pid,
+      pg_class.relname,
+      pg_locks.transactionid,
+      pg_locks.granted,
+      pg_locks.mode,
+      pg_stat_activity.query AS query_snippet,
+      age(now(),pg_stat_activity.query_start) AS "age"
+    FROM pg_stat_activity,pg_locks left
+    OUTER JOIN pg_class
+      ON (pg_locks.relation = pg_class.oid)
+    WHERE pg_stat_activity.query <> '<insufficient privilege>'
+      AND pg_locks.pid = pg_stat_activity.pid
+      AND pg_stat_activity.pid <> pg_backend_pid() order by query_start;
+    """
   end
 end

--- a/lib/queries/bloat.ex
+++ b/lib/queries/bloat.ex
@@ -1,72 +1,84 @@
 defmodule EctoPSQLExtras.Bloat do
-  def title do
-    "Table and index bloat in your database ordered by most wasteful"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Table and index bloat in your database ordered by most wasteful",
+      order_by: [raw_waste: :desc, bloat: :desc],
+      columns: [
+        %{name: :type, type: :string},
+        %{name: :schemaname, type: :string},
+        %{name: :object_name, type: :string},
+        %{name: :bloat, type: :numeric},
+        %{name: :waste, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* Table and index bloat in your database ordered by most wasteful */
+    """
+    /* Table and index bloat in your database ordered by most wasteful */
 
-WITH constants AS (
-  SELECT current_setting('block_size')::numeric AS bs, 23 AS hdr, 4 AS ma
-), bloat_info AS (
-  SELECT
-    ma,bs,schemaname,tablename,
-    (datawidth+(hdr+ma-(case when hdr%ma=0 THEN ma ELSE hdr%ma END)))::numeric AS datahdr,
-    (maxfracsum*(nullhdr+ma-(case when nullhdr%ma=0 THEN ma ELSE nullhdr%ma END))) AS nullhdr2
-  FROM (
+    WITH constants AS (
+      SELECT current_setting('block_size')::numeric AS bs, 23 AS hdr, 4 AS ma
+    ), bloat_info AS (
+      SELECT
+        ma,bs,schemaname,tablename,
+        (datawidth+(hdr+ma-(case when hdr%ma=0 THEN ma ELSE hdr%ma END)))::numeric AS datahdr,
+        (maxfracsum*(nullhdr+ma-(case when nullhdr%ma=0 THEN ma ELSE nullhdr%ma END))) AS nullhdr2
+      FROM (
+        SELECT
+          schemaname, tablename, hdr, ma, bs,
+          SUM((1-null_frac)*avg_width) AS datawidth,
+          MAX(null_frac) AS maxfracsum,
+          hdr+(
+            SELECT 1+count(*)/8
+            FROM pg_stats s2
+            WHERE null_frac<>0 AND s2.schemaname = s.schemaname AND s2.tablename = s.tablename
+          ) AS nullhdr
+        FROM pg_stats s, constants
+        GROUP BY 1,2,3,4,5
+      ) AS foo
+    ), table_bloat AS (
+      SELECT
+        schemaname, tablename, cc.relpages, bs,
+        CEIL((cc.reltuples*((datahdr+ma-
+          (CASE WHEN datahdr%ma=0 THEN ma ELSE datahdr%ma END))+nullhdr2+4))/(bs-20::float)) AS otta
+      FROM bloat_info
+      JOIN pg_class cc ON cc.relname = bloat_info.tablename
+      JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
+    ), index_bloat AS (
+      SELECT
+        schemaname, tablename, bs,
+        COALESCE(c2.relname,'?') AS iname, COALESCE(c2.reltuples,0) AS ituples, COALESCE(c2.relpages,0) AS ipages,
+        COALESCE(CEIL((c2.reltuples*(datahdr-12))/(bs-20::float)),0) AS iotta -- very rough approximation, assumes all cols
+      FROM bloat_info
+      JOIN pg_class cc ON cc.relname = bloat_info.tablename
+      JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
+      JOIN pg_index i ON indrelid = cc.oid
+      JOIN pg_class c2 ON c2.oid = i.indexrelid
+    )
     SELECT
-      schemaname, tablename, hdr, ma, bs,
-      SUM((1-null_frac)*avg_width) AS datawidth,
-      MAX(null_frac) AS maxfracsum,
-      hdr+(
-        SELECT 1+count(*)/8
-        FROM pg_stats s2
-        WHERE null_frac<>0 AND s2.schemaname = s.schemaname AND s2.tablename = s.tablename
-      ) AS nullhdr
-    FROM pg_stats s, constants
-    GROUP BY 1,2,3,4,5
-  ) AS foo
-), table_bloat AS (
-  SELECT
-    schemaname, tablename, cc.relpages, bs,
-    CEIL((cc.reltuples*((datahdr+ma-
-      (CASE WHEN datahdr%ma=0 THEN ma ELSE datahdr%ma END))+nullhdr2+4))/(bs-20::float)) AS otta
-  FROM bloat_info
-  JOIN pg_class cc ON cc.relname = bloat_info.tablename
-  JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
-), index_bloat AS (
-  SELECT
-    schemaname, tablename, bs,
-    COALESCE(c2.relname,'?') AS iname, COALESCE(c2.reltuples,0) AS ituples, COALESCE(c2.relpages,0) AS ipages,
-    COALESCE(CEIL((c2.reltuples*(datahdr-12))/(bs-20::float)),0) AS iotta -- very rough approximation, assumes all cols
-  FROM bloat_info
-  JOIN pg_class cc ON cc.relname = bloat_info.tablename
-  JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
-  JOIN pg_index i ON indrelid = cc.oid
-  JOIN pg_class c2 ON c2.oid = i.indexrelid
-)
-SELECT
-  type, schemaname, object_name, bloat, pg_size_pretty(raw_waste) as waste
-FROM
-(SELECT
-  'table' as type,
-  schemaname,
-  tablename as object_name,
-  ROUND(CASE WHEN otta=0 THEN 0.0 ELSE table_bloat.relpages/otta::numeric END,1) AS bloat,
-  CASE WHEN relpages < otta THEN '0' ELSE (bs*(table_bloat.relpages-otta)::bigint)::bigint END AS raw_waste
-FROM
-  table_bloat
-    UNION
-SELECT
-  'index' as type,
-  schemaname,
-  tablename || '::' || iname as object_name,
-  ROUND(CASE WHEN iotta=0 OR ipages=0 THEN 0.0 ELSE ipages/iotta::numeric END,1) AS bloat,
-  CASE WHEN ipages < iotta THEN '0' ELSE (bs*(ipages-iotta))::bigint END AS raw_waste
-FROM
-  index_bloat) bloat_summary
-ORDER BY raw_waste DESC, bloat DESC;
-"""
+      type, schemaname, object_name, bloat, pg_size_pretty(raw_waste) as waste
+    FROM
+    (SELECT
+      'table' as type,
+      schemaname,
+      tablename as object_name,
+      ROUND(CASE WHEN otta=0 THEN 0.0 ELSE table_bloat.relpages/otta::numeric END,1) AS bloat,
+      CASE WHEN relpages < otta THEN '0' ELSE (bs*(table_bloat.relpages-otta)::bigint)::bigint END AS raw_waste
+    FROM
+      table_bloat
+        UNION
+    SELECT
+      'index' as type,
+      schemaname,
+      tablename || '::' || iname as object_name,
+      ROUND(CASE WHEN iotta=0 OR ipages=0 THEN 0.0 ELSE ipages/iotta::numeric END,1) AS bloat,
+      CASE WHEN ipages < iotta THEN '0' ELSE (bs*(ipages-iotta))::bigint END AS raw_waste
+    FROM
+      index_bloat) bloat_summary
+    ORDER BY raw_waste DESC, bloat DESC;
+    """
   end
 end

--- a/lib/queries/blocking.ex
+++ b/lib/queries/blocking.ex
@@ -1,26 +1,38 @@
 defmodule EctoPSQLExtras.Blocking do
-  def title do
-    "Queries holding locks other queries are waiting to be released"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Queries holding locks other queries are waiting to be released",
+      columns: [
+        %{name: :blocked_pid, type: :integer},
+        %{name: :blocking_statement, type: :string},
+        %{name: :blocking_duration, type: :interval},
+        %{name: :blocking_pid, type: :integer},
+        %{name: :blocked_statement, type: :string},
+        %{name: :blocked_duration, type: :interval}
+      ]
+    }
   end
 
   def query do
-"""
-/* Queries holding locks other queries are waiting to be released */
+    """
+    /* Queries holding locks other queries are waiting to be released */
 
-SELECT bl.pid AS blocked_pid,
-  ka.query AS blocking_statement,
-  now() - ka.query_start AS blocking_duration,
-  kl.pid AS blocking_pid,
-  a.query AS blocked_statement,
-  now() - a.query_start AS blocked_duration
-FROM pg_catalog.pg_locks bl
-JOIN pg_catalog.pg_stat_activity a
-  ON bl.pid = a.pid
-JOIN pg_catalog.pg_locks kl
-  JOIN pg_catalog.pg_stat_activity ka
-    ON kl.pid = ka.pid
-ON bl.transactionid = kl.transactionid AND bl.pid != kl.pid
-WHERE NOT bl.granted;
-"""
+    SELECT bl.pid AS blocked_pid,
+      ka.query AS blocking_statement,
+      now() - ka.query_start AS blocking_duration,
+      kl.pid AS blocking_pid,
+      a.query AS blocked_statement,
+      now() - a.query_start AS blocked_duration
+    FROM pg_catalog.pg_locks bl
+    JOIN pg_catalog.pg_stat_activity a
+      ON bl.pid = a.pid
+    JOIN pg_catalog.pg_locks kl
+      JOIN pg_catalog.pg_stat_activity ka
+        ON kl.pid = ka.pid
+    ON bl.transactionid = kl.transactionid AND bl.pid != kl.pid
+    WHERE NOT bl.granted;
+    """
   end
 end

--- a/lib/queries/cache_hit.ex
+++ b/lib/queries/cache_hit.ex
@@ -1,21 +1,29 @@
 defmodule EctoPSQLExtras.CacheHit do
-  def title do
-    "Index and table hit rate"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Index and table hit rate",
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :ratio, type: :numeric}
+      ]
+    }
   end
 
   def query do
-"""
-/* Index and table hit rate */
+    """
+    /* Index and table hit rate */
 
-SELECT
-  'index hit rate' AS name,
-  (sum(idx_blks_hit)) / nullif(sum(idx_blks_hit + idx_blks_read),0) AS ratio
-FROM pg_statio_user_indexes
-UNION ALL
-SELECT
- 'table hit rate' AS name,
-  sum(heap_blks_hit) / nullif(sum(heap_blks_hit) + sum(heap_blks_read),0) AS ratio
-FROM pg_statio_user_tables;
-"""
+    SELECT
+      'index hit rate' AS name,
+      (sum(idx_blks_hit)) / nullif(sum(idx_blks_hit + idx_blks_read),0) AS ratio
+    FROM pg_statio_user_indexes
+    UNION ALL
+    SELECT
+     'table hit rate' AS name,
+      sum(heap_blks_hit) / nullif(sum(heap_blks_hit) + sum(heap_blks_read),0) AS ratio
+    FROM pg_statio_user_tables;
+    """
   end
 end

--- a/lib/queries/calls.ex
+++ b/lib/queries/calls.ex
@@ -1,19 +1,33 @@
 defmodule EctoPSQLExtras.Calls do
-  def title do
-    "10 queries that have the highest frequency of execution"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "10 queries that have the highest frequency of execution",
+      limit: 10,
+      order_by: [ncalls: :desc],
+      columns: [
+        %{name: :query, type: :string},
+        %{name: :exec_time, type: :interval},
+        %{name: :prop_exec_time, type: :string},
+        %{name: :ncalls, type: :string},
+        %{name: :sync_io_time, type: :interval}
+      ]
+    }
   end
 
   def query do
-"""
-/* 10 queries that have the highest frequency of execution */
+    """
+    /* 10 queries that have the highest frequency of execution */
 
-SELECT query AS qry,
-interval '1 millisecond' * total_time AS exec_time,
-to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
-to_char(calls, 'FM999G999G990') AS ncalls,
-interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
-FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
-ORDER BY calls DESC LIMIT 10;
-"""
+    SELECT query AS qry,
+    interval '1 millisecond' * total_time AS exec_time,
+    to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+    to_char(calls, 'FM999G999G990') AS ncalls,
+    interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
+    FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+    ORDER BY calls DESC
+    LIMIT 10;
+    """
   end
 end

--- a/lib/queries/extensions.ex
+++ b/lib/queries/extensions.ex
@@ -1,13 +1,26 @@
 defmodule EctoPSQLExtras.Extensions do
-  def title do
-    "Available and installed extensions"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Available and installed extensions",
+      order_by: [:installed_version],
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :default_version, type: :string},
+        %{name: :installed_version, type: :string},
+        %{name: :comment, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* Available and installed extensions */
+    """
+    /* Available and installed extensions */
 
-SELECT * FROM pg_available_extensions ORDER BY installed_version;
-"""
+    SELECT name, default_version, installed_version, comment
+    FROM pg_available_extensions
+    ORDER BY installed_version;
+    """
   end
 end

--- a/lib/queries/index_cache_hit.ex
+++ b/lib/queries/index_cache_hit.ex
@@ -1,25 +1,37 @@
 defmodule EctoPSQLExtras.IndexCacheHit do
-  def title do
-    "Calculates your cache hit rate for reading indexes"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Calculates your cache hit rate for reading indexes",
+      order_by: [ratio: :desc],
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :buffer_hits, type: :integer},
+        %{name: :block_reads, type: :integer},
+        %{name: :total_read, type: :integer},
+        %{name: :ratio, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* Calculates your cache hit rate for reading indexes */
+    """
+    /* Calculates your cache hit rate for reading indexes */
 
-SELECT
-  relname AS name,
-  idx_blks_hit AS buffer_hits,
-  idx_blks_read AS block_reads,
-  idx_blks_hit + idx_blks_read AS total_read,
-  CASE (idx_blks_hit + idx_blks_read)::float
-    WHEN 0 THEN 'Insufficient data'
-    ELSE (idx_blks_hit / (idx_blks_hit + idx_blks_read)::float)::text
-  END ratio
-FROM
-  pg_statio_user_tables
-ORDER BY
-  idx_blks_hit / (idx_blks_hit + idx_blks_read + 1)::float DESC;
-"""
+    SELECT
+      relname AS name,
+      idx_blks_hit AS buffer_hits,
+      idx_blks_read AS block_reads,
+      idx_blks_hit + idx_blks_read AS total_read,
+      CASE (idx_blks_hit + idx_blks_read)::float
+        WHEN 0 THEN 'Insufficient data'
+        ELSE (idx_blks_hit / (idx_blks_hit + idx_blks_read)::float)::text
+      END ratio
+    FROM
+      pg_statio_user_tables
+    ORDER BY
+      idx_blks_hit / (idx_blks_hit + idx_blks_read + 1)::float DESC;
+    """
   end
 end

--- a/lib/queries/index_size.ex
+++ b/lib/queries/index_size.ex
@@ -1,21 +1,30 @@
 defmodule EctoPSQLExtras.IndexSize do
-  def title do
-    "The size of indexes, descending by size"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "The size of indexes, descending by size",
+      order_by: [size: :desc],
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :size, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* The size of indexes, descending by size */
+    """
+    /* The size of indexes, descending by size */
 
-SELECT c.relname AS name,
-  pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
-FROM pg_class c
-LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
-WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
-AND n.nspname !~ '^pg_toast'
-AND c.relkind='i'
-GROUP BY c.relname
-ORDER BY sum(c.relpages) DESC;
-"""
+    SELECT c.relname AS name,
+      pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
+    FROM pg_class c
+    LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+    WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND n.nspname !~ '^pg_toast'
+    AND c.relkind='i'
+    GROUP BY c.relname
+    ORDER BY sum(c.relpages) DESC;
+    """
   end
 end

--- a/lib/queries/index_usage.ex
+++ b/lib/queries/index_usage.ex
@@ -1,22 +1,31 @@
 defmodule EctoPSQLExtras.IndexUsage do
-  def title do
-    "Index hit rate (effective databases are at 99% and up)"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Index hit rate (effective databases are at 99% and up)",
+      columns: [
+        %{name: :relname, type: :string},
+        %{name: :percent_of_times_index_used, type: :string},
+        %{name: :rows_in_table, type: :int}
+      ]
+    }
   end
 
   def query do
-"""
-/* Index hit rate (effective databases are at 99% and up) */
+    """
+    /* Index hit rate (effective databases are at 99% and up) */
 
-SELECT relname,
-   CASE idx_scan
-     WHEN 0 THEN 'Insufficient data'
-     ELSE (100 * idx_scan / (seq_scan + idx_scan))::text
-   END percent_of_times_index_used,
-   n_live_tup rows_in_table
- FROM
-   pg_stat_user_tables
- ORDER BY
-   n_live_tup DESC;
-"""
+    SELECT relname,
+       CASE idx_scan
+         WHEN 0 THEN 'Insufficient data'
+         ELSE (100 * idx_scan / (seq_scan + idx_scan))::text
+       END percent_of_times_index_used,
+       n_live_tup rows_in_table
+     FROM
+       pg_stat_user_tables
+     ORDER BY
+       n_live_tup DESC;
+    """
   end
 end

--- a/lib/queries/kill_all.ex
+++ b/lib/queries/kill_all.ex
@@ -1,16 +1,23 @@
 defmodule EctoPSQLExtras.KillAll do
-  def title do
-    "Kill all the active database connections"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Kill all the active database connections",
+      columns: [
+        %{name: :killed, type: :boolean}
+      ]
+    }
   end
 
   def query do
-"""
-/* Kill all the active database connections */
+    """
+    /* Kill all the active database connections */
 
-SELECT pg_terminate_backend(pid) FROM pg_stat_activity
-  WHERE pid <> pg_backend_pid()
-  AND query <> '<insufficient privilege>'
-  AND datname = current_database();
-"""
+    SELECT pg_terminate_backend(pid) AS killed FROM pg_stat_activity
+      WHERE pid <> pg_backend_pid()
+      AND query <> '<insufficient privilege>'
+      AND datname = current_database();
+    """
   end
 end

--- a/lib/queries/locks.ex
+++ b/lib/queries/locks.ex
@@ -1,27 +1,40 @@
 defmodule EctoPSQLExtras.Locks do
-  def title do
-    "Queries with active exclusive locks"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Queries with active exclusive locks",
+      columns: [
+        %{name: :procpid, type: :integer},
+        %{name: :relname, type: :string},
+        %{name: :transactionid, type: :integer},
+        %{name: :granted, type: :boolean},
+        %{name: :query_snippet, type: :string},
+        %{name: :mode, type: :string},
+        %{name: :age, type: :interval}
+      ]
+    }
   end
 
   def query do
-"""
-/* Queries with active exclusive locks */
+    """
+    /* Queries with active exclusive locks */
 
-SELECT
-  pg_stat_activity.pid,
-  pg_class.relname,
-  pg_locks.transactionid,
-  pg_locks.granted,
-  pg_locks.mode,
-  pg_stat_activity.query AS query_snippet,
-  age(now(),pg_stat_activity.query_start) AS "age"
-FROM pg_stat_activity,pg_locks left
-OUTER JOIN pg_class
-  ON (pg_locks.relation = pg_class.oid)
-WHERE pg_stat_activity.query <> '<insufficient privilege>'
-  AND pg_locks.pid = pg_stat_activity.pid
-  AND pg_locks.mode IN ('ExclusiveLock', 'AccessExclusiveLock', 'RowExclusiveLock')
-  AND pg_stat_activity.pid <> pg_backend_pid() order by query_start;
-"""
+    SELECT
+      pg_stat_activity.pid,
+      pg_class.relname,
+      pg_locks.transactionid,
+      pg_locks.granted,
+      pg_locks.mode,
+      pg_stat_activity.query AS query_snippet,
+      age(now(),pg_stat_activity.query_start) AS "age"
+    FROM pg_stat_activity,pg_locks left
+    OUTER JOIN pg_class
+      ON (pg_locks.relation = pg_class.oid)
+    WHERE pg_stat_activity.query <> '<insufficient privilege>'
+      AND pg_locks.pid = pg_stat_activity.pid
+      AND pg_locks.mode IN ('ExclusiveLock', 'AccessExclusiveLock', 'RowExclusiveLock')
+      AND pg_stat_activity.pid <> pg_backend_pid() order by query_start;
+    """
   end
 end

--- a/lib/queries/long_running_queries.ex
+++ b/lib/queries/long_running_queries.ex
@@ -1,24 +1,33 @@
 defmodule EctoPSQLExtras.LongRunningQueries do
-  def title do
-    "All queries longer than five minutes by descending duration"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "All queries longer than five minutes by descending duration",
+      columns: [
+        %{name: :pid, type: :int},
+        %{name: :duration, type: :interval},
+        %{name: :query, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* All queries longer than five minutes by descending duration */
+    """
+    /* All queries longer than five minutes by descending duration */
 
-SELECT
-  pid,
-  now() - pg_stat_activity.query_start AS duration,
-  query AS query
-FROM
-  pg_stat_activity
-WHERE
-  pg_stat_activity.query <> ''::text
-  AND state <> 'idle'
-  AND now() - pg_stat_activity.query_start > interval '5 minutes'
-ORDER BY
-  now() - pg_stat_activity.query_start DESC;
-"""
+    SELECT
+      pid,
+      now() - pg_stat_activity.query_start AS duration,
+      query AS query
+    FROM
+      pg_stat_activity
+    WHERE
+      pg_stat_activity.query <> ''::text
+      AND state <> 'idle'
+      AND now() - pg_stat_activity.query_start > interval '5 minutes'
+    ORDER BY
+      now() - pg_stat_activity.query_start DESC;
+    """
   end
 end

--- a/lib/queries/mandelbrot.ex
+++ b/lib/queries/mandelbrot.ex
@@ -1,31 +1,38 @@
 defmodule EctoPSQLExtras.Mandelbrot do
-  def title do
-    "The mandelbrot set"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "The mandelbrot set",
+      columns: [
+        %{name: :art, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* The mandelbrot set */
+    """
+    /* The mandelbrot set */
 
-WITH RECURSIVE Z(IX, IY, CX, CY, X, Y, I) AS (
-          SELECT IX, IY, X::float, Y::float, X::float, Y::float, 0
-          FROM (select -2.2 + 0.031 * i, i from generate_series(0,101) as i) as xgen(x,ix),
-               (select -1.5 + 0.031 * i, i from generate_series(0,101) as i) as ygen(y,iy)
-          UNION ALL
-          SELECT IX, IY, CX, CY, X * X - Y * Y + CX AS X, Y * X * 2 + CY, I + 1
+    WITH RECURSIVE Z(IX, IY, CX, CY, X, Y, I) AS (
+              SELECT IX, IY, X::float, Y::float, X::float, Y::float, 0
+              FROM (select -2.2 + 0.031 * i, i from generate_series(0,101) as i) as xgen(x,ix),
+                   (select -1.5 + 0.031 * i, i from generate_series(0,101) as i) as ygen(y,iy)
+              UNION ALL
+              SELECT IX, IY, CX, CY, X * X - Y * Y + CX AS X, Y * X * 2 + CY, I + 1
+              FROM Z
+              WHERE X * X + Y * Y < 16::float
+              AND I < 100
+        )
+    SELECT array_to_string(array_agg(SUBSTRING(' .,,,-----++++%%%%@@@@#### ', LEAST(GREATEST(I,1),27), 1)),'') AS art
+    FROM (
+          SELECT IX, IY, MAX(I) AS I
           FROM Z
-          WHERE X * X + Y * Y < 16::float
-          AND I < 100
-    )
-SELECT array_to_string(array_agg(SUBSTRING(' .,,,-----++++%%%%@@@@#### ', LEAST(GREATEST(I,1),27), 1)),'')
-FROM (
-      SELECT IX, IY, MAX(I) AS I
-      FROM Z
-      GROUP BY IY, IX
-      ORDER BY IY, IX
-     ) AS ZT
-GROUP BY IY
-ORDER BY IY;
-"""
+          GROUP BY IY, IX
+          ORDER BY IY, IX
+         ) AS ZT
+    GROUP BY IY
+    ORDER BY IY;
+    """
   end
 end

--- a/lib/queries/outliers.ex
+++ b/lib/queries/outliers.ex
@@ -1,20 +1,33 @@
 defmodule EctoPSQLExtras.Outliers do
-  def title do
-    "10 queries that have longest execution time in aggregate"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "10 queries that have longest execution time in aggregate",
+      order_by: [total_time: :desc],
+      limit: 10,
+      columns: [
+        %{name: :query, type: :string},
+        %{name: :exec_time, type: :interval},
+        %{name: :prop_exec_time, type: :string},
+        %{name: :ncalls, type: :string},
+        %{name: :sync_io_time, type: :interval}
+      ]
+    }
   end
 
   def query do
-"""
-/* 10 queries that have longest execution time in aggregate */
+    """
+    /* 10 queries that have longest execution time in aggregate */
 
-SELECT interval '1 millisecond' * total_time AS total_exec_time,
-to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
-to_char(calls, 'FM999G999G999G990') AS ncalls,
-interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
-query AS query
-FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
-ORDER BY total_time DESC
-LIMIT 10;
-"""
+    SELECT query AS qry,
+    interval '1 millisecond' * total_time AS exec_time,
+    to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+    to_char(calls, 'FM999G999G999G990') AS ncalls,
+    interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
+    FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+    ORDER BY total_time DESC
+    LIMIT 10;
+    """
   end
 end

--- a/lib/queries/records_rank.ex
+++ b/lib/queries/records_rank.ex
@@ -1,19 +1,28 @@
 defmodule EctoPSQLExtras.RecordsRank do
-  def title do
-    "All tables and the number of rows in each ordered by number of rows descending"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "All tables and the number of rows in each ordered by number of rows descending",
+      order_by: [estimated_count: :desc],
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :estimated_count, type: :integer}
+      ]
+    }
   end
 
   def query do
-"""
-/* All tables and the number of rows in each ordered by number of rows descending */
+    """
+    /* All tables and the number of rows in each ordered by number of rows descending */
 
-SELECT
-  relname AS name,
-  n_live_tup AS estimated_count
-FROM
-  pg_stat_user_tables
-ORDER BY
-  n_live_tup DESC;
-"""
+    SELECT
+      relname AS name,
+      n_live_tup AS estimated_count
+    FROM
+      pg_stat_user_tables
+    ORDER BY
+      n_live_tup DESC;
+    """
   end
 end

--- a/lib/queries/seq_scans.ex
+++ b/lib/queries/seq_scans.ex
@@ -1,17 +1,26 @@
 defmodule EctoPSQLExtras.SeqScans do
-  def title do
-    "Count of sequential scans by table descending by order"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Count of sequential scans by table descending by order",
+      order_by: [count: :desc],
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :count, type: :integer}
+      ]
+    }
   end
 
   def query do
-"""
-/* Count of sequential scans by table descending by order */
+    """
+    /* Count of sequential scans by table descending by order */
 
-SELECT relname AS name,
-       seq_scan as count
-FROM
-  pg_stat_user_tables
-ORDER BY seq_scan DESC;
-"""
+    SELECT relname AS name,
+           seq_scan as count
+    FROM
+      pg_stat_user_tables
+    ORDER BY seq_scan DESC;
+    """
   end
 end

--- a/lib/queries/table_cache_hit.ex
+++ b/lib/queries/table_cache_hit.ex
@@ -1,25 +1,37 @@
 defmodule EctoPSQLExtras.TableCacheHit do
-  def title do
-    "Calculates your cache hit rate for reading tables"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Calculates your cache hit rate for reading tables",
+      order_by: [ratio: :desc],
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :buffer_hits, type: :integer},
+        %{name: :block_reads, type: :integer},
+        %{name: :total_read, type: :integer},
+        %{name: :ratio, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* Calculates your cache hit rate for reading tables */
+    """
+    /* Calculates your cache hit rate for reading tables */
 
-SELECT
-  relname AS name,
-  heap_blks_hit AS buffer_hits,
-  heap_blks_read AS block_reads,
-  heap_blks_hit + heap_blks_read AS total_read,
-  CASE (heap_blks_hit + heap_blks_read)::float
-    WHEN 0 THEN 'Insufficient data'
-    ELSE (heap_blks_hit / (heap_blks_hit + heap_blks_read)::float)::text
-  END ratio
-FROM
-  pg_statio_user_tables
-ORDER BY
-  heap_blks_hit / (heap_blks_hit + heap_blks_read + 1)::float DESC;
-"""
+    SELECT
+      relname AS name,
+      heap_blks_hit AS buffer_hits,
+      heap_blks_read AS block_reads,
+      heap_blks_hit + heap_blks_read AS total_read,
+      CASE (heap_blks_hit + heap_blks_read)::float
+        WHEN 0 THEN 'Insufficient data'
+        ELSE (heap_blks_hit / (heap_blks_hit + heap_blks_read)::float)::text
+      END ratio
+    FROM
+      pg_statio_user_tables
+    ORDER BY
+      heap_blks_hit / (heap_blks_hit + heap_blks_read + 1)::float DESC;
+    """
   end
 end

--- a/lib/queries/table_indexes_size.ex
+++ b/lib/queries/table_indexes_size.ex
@@ -1,20 +1,29 @@
 defmodule EctoPSQLExtras.TableIndexesSize do
-  def title do
-    "Total size of all the indexes on each table, descending by size"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Total size of all the indexes on each table, descending by size",
+      order_by: [size: :desc],
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :size, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* Total size of all the indexes on each table, descending by size */
+    """
+    /* Total size of all the indexes on each table, descending by size */
 
-SELECT c.relname AS table,
-  pg_size_pretty(pg_indexes_size(c.oid)) AS index_size
-FROM pg_class c
-LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
-WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
-AND n.nspname !~ '^pg_toast'
-AND c.relkind IN ('r', 'm')
-ORDER BY pg_indexes_size(c.oid) DESC;
-"""
+    SELECT c.relname AS table,
+      pg_size_pretty(pg_indexes_size(c.oid)) AS index_size
+    FROM pg_class c
+    LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+    WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND n.nspname !~ '^pg_toast'
+    AND c.relkind IN ('r', 'm')
+    ORDER BY pg_indexes_size(c.oid) DESC;
+    """
   end
 end

--- a/lib/queries/table_size.ex
+++ b/lib/queries/table_size.ex
@@ -1,20 +1,29 @@
 defmodule EctoPSQLExtras.TableSize do
-  def title do
-    "Size of the tables (excluding indexes), descending by size"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Size of the tables (excluding indexes), descending by size",
+      order_by: [size: :desc],
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :size, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* Size of the tables (excluding indexes), descending by size */
+    """
+    /* Size of the tables (excluding indexes), descending by size */
 
-SELECT c.relname AS name,
-  pg_size_pretty(pg_table_size(c.oid)) AS size
-FROM pg_class c
-LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
-WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
-AND n.nspname !~ '^pg_toast'
-AND c.relkind IN ('r', 'm')
-ORDER BY pg_table_size(c.oid) DESC;
-"""
+    SELECT c.relname AS name,
+      pg_size_pretty(pg_table_size(c.oid)) AS size
+    FROM pg_class c
+    LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+    WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND n.nspname !~ '^pg_toast'
+    AND c.relkind IN ('r', 'm')
+    ORDER BY pg_table_size(c.oid) DESC;
+    """
   end
 end

--- a/lib/queries/total_index_size.ex
+++ b/lib/queries/total_index_size.ex
@@ -1,18 +1,26 @@
 defmodule EctoPSQLExtras.TotalIndexSize do
-  def title do
-    "Total size of all indexes in MB"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Total size of all indexes in MB",
+      limit: 1,
+      columns: [
+        %{name: :size, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* Total size of all indexes in MB */
+    """
+    /* Total size of all indexes in MB */
 
-SELECT pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
-FROM pg_class c
-LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
-WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
-AND n.nspname !~ '^pg_toast'
-AND c.relkind='i';
-"""
+    SELECT pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
+    FROM pg_class c
+    LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+    WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND n.nspname !~ '^pg_toast'
+    AND c.relkind='i';
+    """
   end
 end

--- a/lib/queries/total_table_size.ex
+++ b/lib/queries/total_table_size.ex
@@ -1,20 +1,29 @@
 defmodule EctoPSQLExtras.TotalTableSize do
-  def title do
-    "Size of the tables (including indexes), descending by size"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Size of the tables (including indexes), descending by size",
+      order_by: [size: :desc],
+      columns: [
+        %{name: :name, type: :string},
+        %{name: :size, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* Size of the tables (including indexes), descending by size */
+    """
+    /* Size of the tables (including indexes), descending by size */
 
-SELECT c.relname AS name,
-  pg_size_pretty(pg_total_relation_size(c.oid)) AS size
-FROM pg_class c
-LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
-WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
-AND n.nspname !~ '^pg_toast'
-AND c.relkind IN ('r', 'm')
-ORDER BY pg_total_relation_size(c.oid) DESC;
-"""
+    SELECT c.relname AS name,
+      pg_size_pretty(pg_total_relation_size(c.oid)) AS size
+    FROM pg_class c
+    LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+    WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND n.nspname !~ '^pg_toast'
+    AND c.relkind IN ('r', 'm')
+    ORDER BY pg_total_relation_size(c.oid) DESC;
+    """
   end
 end

--- a/lib/queries/unused_indexes.ex
+++ b/lib/queries/unused_indexes.ex
@@ -1,26 +1,36 @@
 defmodule EctoPSQLExtras.UnusedIndexes do
-  def title do
-    "Unused and almost unused indexes"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Unused and almost unused indexes",
+      columns: [
+        %{name: :table, type: :string},
+        %{name: :index, type: :string},
+        %{name: :index_size, type: :string},
+        %{name: :index_scans, type: :integer}
+      ]
+    }
   end
 
   def query do
-"""
-/* Unused and almost unused indexes */
-/* Ordered by their size relative to the number of index scans.
-Exclude indexes of very small tables (less than 5 pages),
-where the planner will almost invariably select a sequential scan,
-but may not in the future as the table grows */
+    """
+    /* Unused and almost unused indexes */
+    /* Ordered by their size relative to the number of index scans.
+    Exclude indexes of very small tables (less than 5 pages),
+    where the planner will almost invariably select a sequential scan,
+    but may not in the future as the table grows */
 
-SELECT
-  schemaname || '.' || relname AS table,
-  indexrelname AS index,
-  pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
-  idx_scan as index_scans
-FROM pg_stat_user_indexes ui
-JOIN pg_index i ON ui.indexrelid = i.indexrelid
-WHERE NOT indisunique AND idx_scan < 50 AND pg_relation_size(relid) > 5 * 8192
-ORDER BY pg_relation_size(i.indexrelid) / nullif(idx_scan, 0) DESC NULLS FIRST,
-pg_relation_size(i.indexrelid) DESC;
-"""
+    SELECT
+      schemaname || '.' || relname AS table,
+      indexrelname AS index,
+      pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
+      idx_scan as index_scans
+    FROM pg_stat_user_indexes ui
+    JOIN pg_index i ON ui.indexrelid = i.indexrelid
+    WHERE NOT indisunique AND idx_scan < 50 AND pg_relation_size(relid) > 5 * 8192
+    ORDER BY pg_relation_size(i.indexrelid) / nullif(idx_scan, 0) DESC NULLS FIRST,
+    pg_relation_size(i.indexrelid) DESC;
+    """
   end
 end

--- a/lib/queries/vacuum_stats.ex
+++ b/lib/queries/vacuum_stats.ex
@@ -1,50 +1,64 @@
 defmodule EctoPSQLExtras.VacuumStats do
-  def title do
-    "Dead rows and whether an automatic vacuum is expected to be triggered"
+  @behaviour EctoPSQLExtras
+
+  def info do
+    %{
+      title: "Dead rows and whether an automatic vacuum is expected to be triggered",
+      columns: [
+        %{name: :schema, type: :string},
+        %{name: :table, type: :string},
+        %{name: :last_vacuum, type: :string},
+        %{name: :last_autovacuum, type: :string},
+        %{name: :rowcount, type: :string},
+        %{name: :dead_rowcount, type: :string},
+        %{name: :autovacuum_threshold, type: :string},
+        %{name: :expect_autovacuum, type: :string}
+      ]
+    }
   end
 
   def query do
-"""
-/* Dead rows and whether an automatic vacuum is expected to be triggered */
+    """
+    /* Dead rows and whether an automatic vacuum is expected to be triggered */
 
-WITH table_opts AS (
-  SELECT
-    pg_class.oid, relname, nspname, array_to_string(reloptions, '') AS relopts
-  FROM
-     pg_class INNER JOIN pg_namespace ns ON relnamespace = ns.oid
-), vacuum_settings AS (
-  SELECT
-    oid, relname, nspname,
-    CASE
-      WHEN relopts LIKE '%autovacuum_vacuum_threshold%'
-        THEN substring(relopts, '.*autovacuum_vacuum_threshold=([0-9.]+).*')::integer
-        ELSE current_setting('autovacuum_vacuum_threshold')::integer
-      END AS autovacuum_vacuum_threshold,
-    CASE
-      WHEN relopts LIKE '%autovacuum_vacuum_scale_factor%'
-        THEN substring(relopts, '.*autovacuum_vacuum_scale_factor=([0-9.]+).*')::real
-        ELSE current_setting('autovacuum_vacuum_scale_factor')::real
-      END AS autovacuum_vacuum_scale_factor
-  FROM
-    table_opts
-)
-SELECT
-  vacuum_settings.nspname AS schema,
-  vacuum_settings.relname AS table,
-  to_char(psut.last_vacuum, 'YYYY-MM-DD HH24:MI') AS last_vacuum,
-  to_char(psut.last_autovacuum, 'YYYY-MM-DD HH24:MI') AS last_autovacuum,
-  to_char(pg_class.reltuples, '9G999G999G999') AS rowcount,
-  to_char(psut.n_dead_tup, '9G999G999G999') AS dead_rowcount,
-  to_char(autovacuum_vacuum_threshold
-       + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples), '9G999G999G999') AS autovacuum_threshold,
-  CASE
-    WHEN autovacuum_vacuum_threshold + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples) < psut.n_dead_tup
-    THEN 'yes'
-  END AS expect_autovacuum
-FROM
-  pg_stat_user_tables psut INNER JOIN pg_class ON psut.relid = pg_class.oid
-    INNER JOIN vacuum_settings ON pg_class.oid = vacuum_settings.oid
-ORDER BY 1;
-"""
+    WITH table_opts AS (
+      SELECT
+        pg_class.oid, relname, nspname, array_to_string(reloptions, '') AS relopts
+      FROM
+         pg_class INNER JOIN pg_namespace ns ON relnamespace = ns.oid
+    ), vacuum_settings AS (
+      SELECT
+        oid, relname, nspname,
+        CASE
+          WHEN relopts LIKE '%autovacuum_vacuum_threshold%'
+            THEN substring(relopts, '.*autovacuum_vacuum_threshold=([0-9.]+).*')::integer
+            ELSE current_setting('autovacuum_vacuum_threshold')::integer
+          END AS autovacuum_vacuum_threshold,
+        CASE
+          WHEN relopts LIKE '%autovacuum_vacuum_scale_factor%'
+            THEN substring(relopts, '.*autovacuum_vacuum_scale_factor=([0-9.]+).*')::real
+            ELSE current_setting('autovacuum_vacuum_scale_factor')::real
+          END AS autovacuum_vacuum_scale_factor
+      FROM
+        table_opts
+    )
+    SELECT
+      vacuum_settings.nspname AS schema,
+      vacuum_settings.relname AS table,
+      to_char(psut.last_vacuum, 'YYYY-MM-DD HH24:MI') AS last_vacuum,
+      to_char(psut.last_autovacuum, 'YYYY-MM-DD HH24:MI') AS last_autovacuum,
+      to_char(pg_class.reltuples, '9G999G999G999') AS rowcount,
+      to_char(psut.n_dead_tup, '9G999G999G999') AS dead_rowcount,
+      to_char(autovacuum_vacuum_threshold
+           + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples), '9G999G999G999') AS autovacuum_threshold,
+      CASE
+        WHEN autovacuum_vacuum_threshold + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples) < psut.n_dead_tup
+        THEN 'yes'
+      END AS expect_autovacuum
+    FROM
+      pg_stat_user_tables psut INNER JOIN pg_class ON psut.relid = pg_class.oid
+        INNER JOIN vacuum_settings ON pg_class.oid = vacuum_settings.oid
+    ORDER BY 1;
+    """
   end
 end


### PR DESCRIPTION
We define a `EctoPSQLExtras` behaviour which expects
queries to define a `info/0` function, which return the
query title, its columns, as well as optional limit and
order by information.

This gives us a great deal of reflection into each query
and their returned results.
