### PR TITLE
Depend on ecto_sql

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,24 +18,23 @@ defmodule EctoPSQLExtras.Mixfile do
 
   def deps() do
     [
-      { :table_rex, "~> 3.0.0" },
-      { :ecto, "~> 3.4" },
-      { :ex_doc, ">= 0.0.0", only: :dev, runtime: false }
+      {:table_rex, "~> 3.0.0"},
+      {:ecto_sql, "~> 3.4"},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end
 
   defp description() do
     """
-Ecto PostgreSQL database performance insights. Locks, index usage, buffer cache hit ratios, vacuum stats and more.
-"""
+    Ecto PostgreSQL database performance insights. Locks, index usage, buffer cache hit ratios, vacuum stats and more.
+    """
   end
 
   defp package() do
     [
-      files: ["lib/ecto_psql_extras.ex", "mix.exs", "lib/queries/*"],
       maintainers: ["Pawel Urbanek"],
       licenses: ["MIT"],
-      links: %{ "GitHub" => @github_url }
+      links: %{"GitHub" => @github_url}
     ]
   end
 end


### PR DESCRIPTION
We also formatted `mix.exs` and remove unneeded options.