### PR TITLE
Misc HTML doc changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2020 Pawel Urbanek.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ecto PSQL Extras [![Hex.pm](https://img.shields.io/hexpm/v/ecto_psql_extras.svg)](http://hex.pm/packages/ecto_psql_extras) [![CI](https://github.com/pawurb/ecto_psql_extras/workflows/CI/badge.svg)](https://github.com/pawurb/ecto_psql_extras/actions)
+# Ecto PSQL Extras [![Hex.pm](https://img.shields.io/hexpm/v/ecto_psql_extras.svg)](http://hex.pm/packages/ecto_psql_extras) [![Hex.pm](https://img.shields.io/hexpm/dt/ecto_psql_extras.svg)](https://hex.pm/packages/ecto_psql_extras) [![Hex.pm](https://img.shields.io/hexpm/l/ecto_psql_extras.svg)](https://github.com/pawurb/ecto_psql_extras/blob/master/LICENSE) [![CI](https://github.com/pawurb/ecto_psql_extras/workflows/CI/badge.svg)](https://github.com/pawurb/ecto_psql_extras/actions)
 
 Elixir port of [Heroku PG Extras](https://github.com/heroku/heroku-pg-extras). The goal of this project is to provide powerful insights into the PostgreSQL database for Elixir apps that are not using the Heroku PostgreSQL plugin.
 
@@ -107,7 +107,7 @@ EctoPSQLExtras.query(:index_cache_hit, YourApp.Repo)
 (truncated results for brevity)
 ```
 
-The same as `cache_hit` with each table's indexes cache hit info displayed seperately.
+The same as `cache_hit` with each table's indexes cache hit info displayed separately.
 
 ### `table_cache_hit`
 
@@ -123,7 +123,7 @@ EctoPSQLExtras.query(:table_cache_hit, YourApp.Repo)
 (truncated results for brevity)
 ```
 
-The same as `cache_hit` with each table's cache hit info displayed seperately.
+The same as `cache_hit` with each table's cache hit info displayed separately.
 
 ### `index_usage`
 
@@ -160,7 +160,7 @@ EctoPSQLExtras.query(:locks, YourApp.Repo)
 (4 rows)
 ```
 
-This command displays queries that have taken out an exlusive lock on a relation. Exclusive locks typically prevent other operations on that relation from taking place, and can be a cause of "hung" queries that are waiting for a lock to be granted.
+This command displays queries that have taken out an exclusive lock on a relation. Exclusive locks typically prevent other operations on that relation from taking place, and can be a cause of "hung" queries that are waiting for a lock to be granted.
 
 ### `all_locks`
 
@@ -190,7 +190,7 @@ EctoPSQLExtras.query(:outliers, YourApp.Repo)
 (truncated results for brevity)
 ```
 
-This command displays statements, obtained from `pg_stat_statements`, ordered by the amount of time to execute in aggregate. This includes the statement itself, the total execution time for that statement, the proportion of total execution time for all statements that statement has taken up, the number of times that statement has been called, and the amount of time that statement spent on synchronous I/O (reading/writing from the filesystem).
+This command displays statements, obtained from `pg_stat_statements`, ordered by the amount of time to execute in aggregate. This includes the statement itself, the total execution time for that statement, the proportion of total execution time for all statements that statement has taken up, the number of times that statement has been called, and the amount of time that statement spent on synchronous I/O (reading/writing from the file system).
 
 Typically, an efficient query will have an appropriate ratio of calls to total execution time, with as little time spent on I/O as possible. Queries that have a high total execution time but low call count should be investigated to improve their performance. Queries that have a high proportion of execution time being spent on synchronous I/O should also be investigated.
 
@@ -299,7 +299,7 @@ EctoPSQLExtras.query(:table_indexes_size, YourApp.Repo)
 (truncated results for brevity)
 ```
 
-This command displays the total size of indexes for each table and materialized view, in MB. It is calcualtes by using the system administration function `pg_indexes_size()`.
+This command displays the total size of indexes for each table and materialized view, in MB. It is calculated by using the system administration function `pg_indexes_size()`.
 
 ### `total_table_size`
 
@@ -355,7 +355,7 @@ EctoPSQLExtras.query(:seq_scans, YourApp.Repo)
 (truncated results for brevity)
 ```
 
-This command displays the number of sequential scans recorded against all tables, descending by count of sequential scans. Tables that have very high numbers of sequential scans may be underindexed, and it may be worth investigating queries that read from these tables.
+This command displays the number of sequential scans recorded against all tables, descending by count of sequential scans. Tables that have very high numbers of sequential scans may be under-indexed, and it may be worth investigating queries that read from these tables.
 
 ### `long_running_queries`
 
@@ -428,7 +428,7 @@ EctoPSQLExtras.query(:vacuum_stats, YourApp.Repo)
  (truncated results for brevity)
 ```
 
-This command displays statistics related to vacuum operations for each table, including an estiamtion of dead rows, last autovacuum and the current autovacuum threshold. This command can be useful when determining if current vacuum thresholds require adjustments, and to determine when the table was last vacuumed.
+This command displays statistics related to vacuum operations for each table, including an estimation of dead rows, last autovacuum and the current autovacuum threshold. This command can be useful when determining if current vacuum thresholds require adjustments, and to determine when the table was last vacuumed.
 
 ### `kill_all`
 

--- a/mix.exs
+++ b/mix.exs
@@ -12,11 +12,11 @@ defmodule EctoPSQLExtras.Mixfile do
       description: description(),
       deps: deps(),
       package: package(),
-      source_url: @github_url
+      docs: docs()
     ]
   end
 
-  def deps() do
+  def deps do
     [
       {:table_rex, "~> 3.0.0"},
       {:ecto_sql, "~> 3.4"},
@@ -25,17 +25,25 @@ defmodule EctoPSQLExtras.Mixfile do
     ]
   end
 
-  defp description() do
+  defp description do
     """
     Ecto PostgreSQL database performance insights. Locks, index usage, buffer cache hit ratios, vacuum stats and more.
     """
   end
 
-  defp package() do
+  defp package do
     [
       maintainers: ["Pawel Urbanek"],
       licenses: ["MIT"],
       links: %{"GitHub" => @github_url}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      source_url: @github_url,
+      extras: ["README.md"]
     ]
   end
 end


### PR DESCRIPTION
The primary change is to set the `README` as the default page in HexDocs so we can read and search through the tutorial doc as well as API doc at one page.

List of changes:

- No parenthesis for function without args
- Set readme as default HTML doc page
- Fix typos
- Add missing license file
- Badges and more badges!