### PR TITLE
Handle different columns for older versions of pg_stat_statements

### DIFF
--- a/lib/queries/calls.ex
+++ b/lib/queries/calls.ex
@@ -21,8 +21,8 @@ defmodule EctoPSQLExtras.Calls do
     /* 10 queries that have the highest frequency of execution */
 
     SELECT query AS query,
-    interval '1 millisecond' * total_time AS exec_time,
-    (total_time/sum(total_time) OVER())  AS exec_time_ratio,
+    interval '1 millisecond' * total_exec_time AS exec_time,
+    (total_exec_time/sum(total_exec_time) OVER())  AS exec_time_ratio,
     calls,
     interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
     FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)

--- a/lib/queries/calls_legacy.ex
+++ b/lib/queries/calls_legacy.ex
@@ -1,11 +1,11 @@
-defmodule EctoPSQLExtras.Outliers do
+defmodule EctoPSQLExtras.CallsLegacy do
   @behaviour EctoPSQLExtras
 
   def info do
     %{
-      title: "10 queries that have longest execution time in aggregate",
-      order_by: [exec_time: :desc],
+      title: "10 queries that have the highest frequency of execution",
       limit: 10,
+      order_by: [calls: :desc],
       columns: [
         %{name: :query, type: :string},
         %{name: :exec_time, type: :interval},
@@ -18,15 +18,15 @@ defmodule EctoPSQLExtras.Outliers do
 
   def query do
     """
-    /* 10 queries that have longest execution time in aggregate */
+    /* 10 queries that have the highest frequency of execution */
 
     SELECT query AS query,
-    interval '1 millisecond' * total_exec_time AS exec_time,
-    (total_exec_time/sum(total_exec_time) OVER()) AS prop_exec_time,
+    interval '1 millisecond' * total_time AS exec_time,
+    (total_time/sum(total_time) OVER())  AS exec_time_ratio,
     calls,
     interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
     FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
-    ORDER BY total_exec_time DESC
+    ORDER BY calls DESC
     LIMIT 10;
     """
   end

--- a/lib/queries/outliers_legacy.ex
+++ b/lib/queries/outliers_legacy.ex
@@ -1,4 +1,4 @@
-defmodule EctoPSQLExtras.Outliers do
+defmodule EctoPSQLExtras.OutliersLegacy do
   @behaviour EctoPSQLExtras
 
   def info do
@@ -21,12 +21,12 @@ defmodule EctoPSQLExtras.Outliers do
     /* 10 queries that have longest execution time in aggregate */
 
     SELECT query AS query,
-    interval '1 millisecond' * total_exec_time AS exec_time,
-    (total_exec_time/sum(total_exec_time) OVER()) AS prop_exec_time,
+    interval '1 millisecond' * total_time AS exec_time,
+    (total_time/sum(total_time) OVER()) AS prop_exec_time,
     calls,
     interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
     FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
-    ORDER BY total_exec_time DESC
+    ORDER BY total_time DESC
     LIMIT 10;
     """
   end


### PR DESCRIPTION
Fixes #14. Because pg_stat_statements >= 1.8.0 uses different columns, outliers and calls need slightly different queries. This needs to be detected directly in the database, and since the repo is only ever passed into `query/3`, I saw a couple options:

1. Pass the repo into every query module's `query` function (but that would mean changing 20+ modules for something that only affects 2 of them
2. Detect the version in the `queries` function and call either current or legacy calls/outliers modules (however, this does result in near-duplicates for Calls/CallsLegacy and Outliers/OutliersLegacy).
3. Somehow grab the version in the actual Postgres query (I'm sure someone smarter than me could figure this out, but I couldn't quickly find a way)

I went with option 2, but any feedback is welcome. It's working this way for now in my production app.
