### PR TITLE
Fix EctoPSQLExtras.queries failing

### DIFF
--- a/lib/ecto_psql_extras.ex
+++ b/lib/ecto_psql_extras.ex
@@ -126,6 +126,6 @@ defmodule EctoPSQLExtras do
         "select installed_version from pg_available_extensions where name='pg_stat_statements'"
       ).rows
 
-    Postgrex.Utils.parse_version(value)
+    value && Postgrex.Utils.parse_version(value)
   end
 end


### PR DESCRIPTION
EctoPSQLExtras.queries will raise if there is no pg_stat_statements preventing to at least use the other queries in e.g. Phoenix LiveDashboard