### PR TITLE
Tag all queries originating from his module, and ignore them

### DIFF
--- a/lib/queries/all_locks.ex
+++ b/lib/queries/all_locks.ex
@@ -18,7 +18,7 @@ defmodule EctoPSQLExtras.AllLocks do
 
   def query do
     """
-    /* Queries with active locks */
+    /* ECTO_PSQL_EXTRAS: Queries with active locks */
 
     SELECT
       pg_stat_activity.pid,

--- a/lib/queries/bloat.ex
+++ b/lib/queries/bloat.ex
@@ -17,7 +17,7 @@ defmodule EctoPSQLExtras.Bloat do
 
   def query do
     """
-    /* Table and index bloat in your database ordered by most wasteful */
+    /* ECTO_PSQL_EXTRAS: Table and index bloat in your database ordered by most wasteful */
 
     WITH constants AS (
       SELECT current_setting('block_size')::numeric AS bs, 23 AS hdr, 4 AS ma

--- a/lib/queries/blocking.ex
+++ b/lib/queries/blocking.ex
@@ -17,7 +17,7 @@ defmodule EctoPSQLExtras.Blocking do
 
   def query do
     """
-    /* Queries holding locks other queries are waiting to be released */
+    /* ECTO_PSQL_EXTRAS: Queries holding locks other queries are waiting to be released */
 
     SELECT bl.pid AS blocked_pid,
       ka.query AS blocking_statement,

--- a/lib/queries/cache_hit.ex
+++ b/lib/queries/cache_hit.ex
@@ -13,7 +13,7 @@ defmodule EctoPSQLExtras.CacheHit do
 
   def query do
     """
-    /* Index and table hit rate */
+    /* ECTO_PSQL_EXTRAS: Index and table hit rate */
 
     SELECT
       'index hit rate' AS name,

--- a/lib/queries/calls.ex
+++ b/lib/queries/calls.ex
@@ -18,7 +18,7 @@ defmodule EctoPSQLExtras.Calls do
 
   def query do
     """
-    /* 10 queries that have the highest frequency of execution */
+    /* ECTO_PSQL_EXTRAS: 10 queries that have the highest frequency of execution */
 
     SELECT query AS query,
     interval '1 millisecond' * total_exec_time AS exec_time,
@@ -26,6 +26,7 @@ defmodule EctoPSQLExtras.Calls do
     calls,
     interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
     FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+    AND query NOT LIKE '/* ECTO_PSQL_EXTRAS:%'
     ORDER BY calls DESC
     LIMIT 10;
     """

--- a/lib/queries/calls_legacy.ex
+++ b/lib/queries/calls_legacy.ex
@@ -18,7 +18,7 @@ defmodule EctoPSQLExtras.CallsLegacy do
 
   def query do
     """
-    /* 10 queries that have the highest frequency of execution */
+    /* ECTO_PSQL_EXTRAS: 10 queries that have the highest frequency of execution */
 
     SELECT query AS query,
     interval '1 millisecond' * total_time AS exec_time,
@@ -26,6 +26,7 @@ defmodule EctoPSQLExtras.CallsLegacy do
     calls,
     interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
     FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+    AND query NOT LIKE '/* ECTO_PSQL_EXTRAS:%'
     ORDER BY calls DESC
     LIMIT 10;
     """

--- a/lib/queries/extensions.ex
+++ b/lib/queries/extensions.ex
@@ -16,7 +16,7 @@ defmodule EctoPSQLExtras.Extensions do
 
   def query do
     """
-    /* Available and installed extensions */
+    /* ECTO_PSQL_EXTRAS: Available and installed extensions */
 
     SELECT name, default_version, installed_version, comment
     FROM pg_available_extensions

--- a/lib/queries/index_cache_hit.ex
+++ b/lib/queries/index_cache_hit.ex
@@ -18,7 +18,7 @@ defmodule EctoPSQLExtras.IndexCacheHit do
 
   def query do
     """
-    /* Calculates your cache hit rate for reading indexes */
+    /* ECTO_PSQL_EXTRAS: Calculates your cache hit rate for reading indexes */
 
     SELECT
       schemaname AS schema, relname AS name,

--- a/lib/queries/index_size.ex
+++ b/lib/queries/index_size.ex
@@ -15,7 +15,7 @@ defmodule EctoPSQLExtras.IndexSize do
 
   def query do
     """
-    /* The size of indexes, descending by size */
+    /* ECTO_PSQL_EXTRAS: The size of indexes, descending by size */
 
     SELECT n.nspname AS schema, c.relname AS name, sum(c.relpages::bigint*8192)::bigint AS size
     FROM pg_class c

--- a/lib/queries/index_usage.ex
+++ b/lib/queries/index_usage.ex
@@ -15,7 +15,7 @@ defmodule EctoPSQLExtras.IndexUsage do
 
   def query do
     """
-    /* Index hit rate (effective databases are at 99% and up) */
+    /* ECTO_PSQL_EXTRAS: Index hit rate (effective databases are at 99% and up) */
 
     SELECT schemaname AS schema, relname AS name,
        CASE idx_scan

--- a/lib/queries/kill_all.ex
+++ b/lib/queries/kill_all.ex
@@ -12,7 +12,7 @@ defmodule EctoPSQLExtras.KillAll do
 
   def query do
     """
-    /* Kill all the active database connections */
+    /* ECTO_PSQL_EXTRAS: Kill all the active database connections */
 
     SELECT pg_terminate_backend(pid) AS killed FROM pg_stat_activity
       WHERE pid <> pg_backend_pid()

--- a/lib/queries/locks.ex
+++ b/lib/queries/locks.ex
@@ -18,7 +18,7 @@ defmodule EctoPSQLExtras.Locks do
 
   def query do
     """
-    /* Queries with active exclusive locks */
+    /* ECTO_PSQL_EXTRAS: Queries with active exclusive locks */
 
     SELECT
       pg_stat_activity.pid,

--- a/lib/queries/long_running_queries.ex
+++ b/lib/queries/long_running_queries.ex
@@ -15,7 +15,7 @@ defmodule EctoPSQLExtras.LongRunningQueries do
 
   def query do
     """
-    /* All queries longer than five minutes by descending duration */
+    /* ECTO_PSQL_EXTRAS: All queries longer than five minutes by descending duration */
 
     SELECT
       pid,

--- a/lib/queries/mandelbrot.ex
+++ b/lib/queries/mandelbrot.ex
@@ -12,7 +12,7 @@ defmodule EctoPSQLExtras.Mandelbrot do
 
   def query do
     """
-    /* The mandelbrot set */
+    /* ECTO_PSQL_EXTRAS: The mandelbrot set */
 
     WITH RECURSIVE Z(IX, IY, CX, CY, X, Y, I) AS (
               SELECT IX, IY, X::float, Y::float, X::float, Y::float, 0

--- a/lib/queries/outliers.ex
+++ b/lib/queries/outliers.ex
@@ -18,7 +18,7 @@ defmodule EctoPSQLExtras.Outliers do
 
   def query do
     """
-    /* 10 queries that have longest execution time in aggregate */
+    /* ECTO_PSQL_EXTRAS: 10 queries that have longest execution time in aggregate */
 
     SELECT query AS query,
     interval '1 millisecond' * total_exec_time AS exec_time,
@@ -26,6 +26,7 @@ defmodule EctoPSQLExtras.Outliers do
     calls,
     interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
     FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+    AND query NOT LIKE '/* ECTO_PSQL_EXTRAS:%'
     ORDER BY total_exec_time DESC
     LIMIT 10;
     """

--- a/lib/queries/outliers_legacy.ex
+++ b/lib/queries/outliers_legacy.ex
@@ -18,7 +18,7 @@ defmodule EctoPSQLExtras.OutliersLegacy do
 
   def query do
     """
-    /* 10 queries that have longest execution time in aggregate */
+    /* ECTO_PSQL_EXTRAS: 10 queries that have longest execution time in aggregate */
 
     SELECT query AS query,
     interval '1 millisecond' * total_time AS exec_time,
@@ -26,6 +26,7 @@ defmodule EctoPSQLExtras.OutliersLegacy do
     calls,
     interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
     FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+    AND query NOT LIKE '/* ECTO_PSQL_EXTRAS:%'
     ORDER BY total_time DESC
     LIMIT 10;
     """

--- a/lib/queries/records_rank.ex
+++ b/lib/queries/records_rank.ex
@@ -15,7 +15,7 @@ defmodule EctoPSQLExtras.RecordsRank do
 
   def query do
     """
-    /* All tables and the number of rows in each ordered by number of rows descending */
+    /* ECTO_PSQL_EXTRAS: All tables and the number of rows in each ordered by number of rows descending */
 
     SELECT
       schemaname AS schema, relname AS name,

--- a/lib/queries/seq_scans.ex
+++ b/lib/queries/seq_scans.ex
@@ -15,7 +15,7 @@ defmodule EctoPSQLExtras.SeqScans do
 
   def query do
     """
-    /* Count of sequential scans by table descending by order */
+    /* ECTO_PSQL_EXTRAS: Count of sequential scans by table descending by order */
 
     SELECT schemaname AS schema, relname AS name,
            seq_scan as count

--- a/lib/queries/table_cache_hit.ex
+++ b/lib/queries/table_cache_hit.ex
@@ -18,7 +18,7 @@ defmodule EctoPSQLExtras.TableCacheHit do
 
   def query do
     """
-    /* Calculates your cache hit rate for reading tables */
+    /* ECTO_PSQL_EXTRAS: Calculates your cache hit rate for reading tables */
 
     SELECT
       schemaname AS schema, relname AS name,

--- a/lib/queries/table_indexes_size.ex
+++ b/lib/queries/table_indexes_size.ex
@@ -15,7 +15,7 @@ defmodule EctoPSQLExtras.TableIndexesSize do
 
   def query do
     """
-    /* Total size of all the indexes on each table, descending by size */
+    /* ECTO_PSQL_EXTRAS: Total size of all the indexes on each table, descending by size */
 
     SELECT n.nspname AS schema, c.relname AS table, pg_indexes_size(c.oid) AS index_size
     FROM pg_class c

--- a/lib/queries/table_size.ex
+++ b/lib/queries/table_size.ex
@@ -15,7 +15,7 @@ defmodule EctoPSQLExtras.TableSize do
 
   def query do
     """
-    /* Size of the tables (excluding indexes), descending by size */
+    /* ECTO_PSQL_EXTRAS: Size of the tables (excluding indexes), descending by size */
 
     SELECT n.nspname AS schema, c.relname AS name, pg_table_size(c.oid) AS size
     FROM pg_class c

--- a/lib/queries/total_index_size.ex
+++ b/lib/queries/total_index_size.ex
@@ -13,7 +13,7 @@ defmodule EctoPSQLExtras.TotalIndexSize do
 
   def query do
     """
-    /* Total size of all indexes in MB */
+    /* ECTO_PSQL_EXTRAS: Total size of all indexes in MB */
 
     SELECT sum(c.relpages::bigint*8192)::bigint AS size
     FROM pg_class c

--- a/lib/queries/total_table_size.ex
+++ b/lib/queries/total_table_size.ex
@@ -15,7 +15,7 @@ defmodule EctoPSQLExtras.TotalTableSize do
 
   def query do
     """
-    /* Size of the tables (including indexes), descending by size */
+    /* ECTO_PSQL_EXTRAS: Size of the tables (including indexes), descending by size */
 
     SELECT n.nspname AS schema, c.relname AS name, pg_total_relation_size(c.oid) AS size
     FROM pg_class c

--- a/lib/queries/unused_indexes.ex
+++ b/lib/queries/unused_indexes.ex
@@ -16,7 +16,7 @@ defmodule EctoPSQLExtras.UnusedIndexes do
 
   def query do
     """
-    /* Unused and almost unused indexes */
+    /* ECTO_PSQL_EXTRAS: Unused and almost unused indexes */
     /* Ordered by their size relative to the number of index scans.
     Exclude indexes of very small tables (less than 5 pages),
     where the planner will almost invariably select a sequential scan,

--- a/lib/queries/vacuum_stats.ex
+++ b/lib/queries/vacuum_stats.ex
@@ -19,7 +19,7 @@ defmodule EctoPSQLExtras.VacuumStats do
 
   def query do
     """
-    /* Dead rows and whether an automatic vacuum is expected to be triggered */
+    /* ECTO_PSQL_EXTRAS: Dead rows and whether an automatic vacuum is expected to be triggered */
 
     WITH table_opts AS (
       SELECT


### PR DESCRIPTION
Using this with Phoenix Live Dashboard, the queries often get 'poluted' with queries issued by this library. This is not so very useful :) 

This adds a "tag" in the comment (which ends up in the stats!) of every query and then filters out based on that. This increases the signal significantly on some of my systems when looking at calls or outliers.