### PR TITLE
Add tests for pg_stat_statements dependent queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,6 @@ jobs:
   mix_test:
     name: mix test (Elixir ${{matrix.pair.elixir}} | Erlang/OTP ${{matrix.pair.otp}})
     runs-on: ubuntu-18.04
-    services:
-      postgres:
-        image: postgres:11.6-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: ecto_psql_extras_test
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     strategy:
       fail-fast: false
       matrix:
@@ -42,6 +28,16 @@ jobs:
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
+      - name: Run PostgreSQL
+        run: |
+          docker run --env POSTGRES_USER=postgres \
+            --env POSTGRES_DB=ecto_psql_extras_test \
+            --env POSTGRES_PASSWORD=postgres \
+            -d -p 5432:5432 postgres:12.5-alpine \
+            postgres -c shared_preload_libraries=pg_stat_statements \
+            -c pg_stat_statements.track=all \
+            -c max_connections=200
+          sleep 5
       - name: Install Dependencies
         run: |
           mix local.hex --force

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -7,5 +7,6 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: ecto_psql_extras_test
       POSTGRES_PASSWORD: postgres
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200
     ports:
       - '5432:5432'

--- a/test/ecto_psql_extras_test.exs
+++ b/test/ecto_psql_extras_test.exs
@@ -107,11 +107,12 @@ defmodule EctoPSQLExtrasTest do
   describe "database interaction" do
     setup do
       start_supervised!(EctoPSQLExtras.TestRepo)
+      EctoPSQLExtras.TestRepo.query!("CREATE EXTENSION IF NOT EXISTS pg_stat_statements;")
       :ok
     end
 
     test "run queries by param" do
-      for query <- Enum.reduce((queries() |> Map.to_list), [], fn(el, acc) ->
+      for query <- Enum.reduce((queries(TestRepo) |> Map.to_list), [], fn(el, acc) ->
         case elem(el, 0) in @skip_queries do
           true ->
             acc
@@ -156,7 +157,7 @@ defmodule EctoPSQLExtrasTest do
     end
 
     test "run queries by method" do
-      for query <- Enum.reduce((queries() |> Map.to_list), [], fn(el, acc) ->
+      for query <- Enum.reduce((queries(TestRepo) |> Map.to_list), [], fn(el, acc) ->
         case elem(el, 0) in @skip_queries do
           true ->
             acc


### PR DESCRIPTION
This PR adds running tests for queries that are dependent on `pg_stat_statements` extension (`calls` and `outliers`). It works for local tests with docker-compose.yml but I don't know how to add the custom PG extension in GH workflow.

I handle similar case in CircleCI with the following config line:

```
command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200
```

but GH workflow does not seem to support it. There's `container.options` available but I did not manage to use it for customizing the container startup command.

Help appreciated.
