### PR TITLE
make @index_cache_hit_min_expected a float

### DIFF
--- a/lib/ecto_psql_extras/diagnose_logic.ex
+++ b/lib/ecto_psql_extras/diagnose_logic.ex
@@ -6,7 +6,7 @@ defmodule EctoPSQLExtras.DiagnoseLogic do
   require Logger
 
   @table_cache_hit_min_expected 0.985
-  @index_cache_hit_min_expected "0.985"
+  @index_cache_hit_min_expected 0.985
   @unused_indexes_max_scans 20
   @unused_indexes_min_size_bytes 1000000
   @null_indexes_min_size_mb 1 # 1 MB


### PR DESCRIPTION
was getting erroneous false:

`false	index_cache_hit	Index cache hit ratio is too low: 0.99984`

which looked very odd..

the logic very much expects a float