### PR TITLE
Allow postgrex 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,58 @@ jobs:
         run: |
           sleep 4 # wait pg
           mix test --include distribution
+      - name: Install postgrex 0.16 (except on elixir 1.7.4)
+        if: matrix.pair.elixir != '1.7.4'
+        run: |
+          mix deps.unlock --all
+          mix deps.update postgrex
+      - name: Run tests for PG 11/postgrex 0.16 (0.15 on elixir 1.7.4)
+        env:
+          PG_VERSION: 11
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_DB: ecto_psql_extras_test
+          POSTGRES_PASSWORD: postgres
+        run: |
+          sleep 4 # wait pg
+          mix test --include distribution
+      - name: Run tests for PG 12/postgrex 0.16 (0.15 on elixir 1.7.4)
+        env:
+          PG_VERSION: 12
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_DB: ecto_psql_extras_test
+          POSTGRES_PASSWORD: postgres
+        run: |
+          sleep 4 # wait pg
+          mix test --include distribution
+      - name: Run tests for PG 13/postgrex 0.16 (0.15 on elixir 1.7.4)
+        env:
+          PG_VERSION: 13
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_DB: ecto_psql_extras_test
+          POSTGRES_PASSWORD: postgres
+        run: |
+          sleep 4 # wait pg
+          mix test --include distribution
+      - name: Run tests for PG 14/postgrex 0.16 (0.15 on elixir 1.7.4)
+        env:
+          PG_VERSION: 14
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_DB: ecto_psql_extras_test
+          POSTGRES_PASSWORD: postgres
+        run: |
+          sleep 4 # wait pg
+          mix test --include distribution
+      - name: Run tests for PG 15/postgrex 0.16 (0.15 on elixir 1.7.4)
+        env:
+          PG_VERSION: 15
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_DB: ecto_psql_extras_test
+          POSTGRES_PASSWORD: postgres
+        run: |
+          sleep 4 # wait pg
+          mix test --include distribution

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule EctoPSQLExtras.Mixfile do
     [
       {:table_rex, "~> 3.1.1"},
       {:ecto_sql, "~> 3.4"},
-      {:postgrex, "~> 0.15.7"},
+      {:postgrex, "~> 0.15.7 or ~> 0.16.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:mock, "~> 0.3.0", only: :test}
     ]


### PR DESCRIPTION
believe https://github.com/pawurb/ecto_psql_extras/pull/37 limited the ability to run on postgrex 0.16, attempting update to 0.7.8 now gives:

`Because ecto_psql_extras >= 0.7.8 depends on postgrex ~> 0.15.7 and oban >= 2.11.0 depends on postgrex ~> 0.16, ecto_psql_extras >= 0.7.8 is incompatible with oban >= 2.11.0.
And because your app depends on ecto_psql_extras ~> 0.7.8, oban >= 2.11.0 is forbidden. 
So, because your app depends on oban ~> 2.13, version solving failed.`

Including CI changes for testing against postgrex 0.16 - not the prettiest, but better than no CI against postgrex 0.16?