### PR TITLE
Fix diagnose errors

### DIFF
--- a/lib/ecto_psql_extras.ex
+++ b/lib/ecto_psql_extras.ex
@@ -401,7 +401,7 @@ defmodule EctoPSQLExtras do
   def format_value({nil, _}), do: ""
   def format_value({number, :percent}), do: format_percent(number)
   def format_value({integer, :bytes}) when is_integer(integer), do: format_bytes(integer)
-  def format_value({string, :string}), do: String.replace(string, "\n", "")
+  def format_value({string, :string}) when is_binary(string), do: String.replace(string, "\n", "")
   def format_value({binary, _}) when is_binary(binary), do: binary
   def format_value({other, _}), do: inspect(other)
 

--- a/lib/ecto_psql_extras/diagnose_logic.ex
+++ b/lib/ecto_psql_extras/diagnose_logic.ex
@@ -114,9 +114,10 @@ defmodule EctoPSQLExtras.DiagnoseLogic do
     ).rows
     |> Enum.filter(fn(el) ->
       {null_frac, ""} = Enum.at(el, 5)
+      |> String.trim_leading()
       |> String.replace("%", "")
-      |> String.trim_leading
-      |> Float.parse
+      |> String.replace(~r/^\./, "0.")
+      |> Float.parse()
       null_frac > @null_min_null_frac_percent
     end)
 

--- a/test/diagnose_logic_test.exs
+++ b/test/diagnose_logic_test.exs
@@ -35,7 +35,8 @@ defmodule DiagnoseLogicTest do
         rows: [
           ["123", "index_plans_on_payer_id", "16 MB", true, "payer_id", " 0.00%", "0 kb"],
           ["321", "index_feedbacks_on_target_id", "80 kB", false, "target_id", "97.00%", "77 kb"],
-          ["231", "index_channels_on_slack_id", "56 MB", true, "slack_id", "49.99%", "28 MB"]
+          ["231", "index_channels_on_slack_id", "56 MB", true, "slack_id", "49.99%", "28 MB"],
+          [465344, "index_on_line_item_id_index", "1424 kB", true, "line_item_id", "    .07%", "972 bytes"]
         ]
       }
     end,

--- a/test/diagnose_logic_test.exs
+++ b/test/diagnose_logic_test.exs
@@ -1,6 +1,8 @@
 defmodule DiagnoseLogicTest do
   use ExUnit.Case, async: false
   alias EctoPSQLExtras.TestRepo
+
+  import ExUnit.CaptureIO
   import Mock
 
   setup do
@@ -91,7 +93,9 @@ defmodule DiagnoseLogicTest do
       }
     end
   ] do
-    EctoPSQLExtras.diagnose(EctoPSQLExtras.TestRepo)
+    capture_io(fn ->
+      EctoPSQLExtras.diagnose(EctoPSQLExtras.TestRepo)
+    end)
 
     result = EctoPSQLExtras.DiagnoseLogic.run(EctoPSQLExtras.TestRepo)
 
@@ -99,6 +103,7 @@ defmodule DiagnoseLogicTest do
     assert Enum.at(Enum.at(result.rows, 0), 1) == "table_cache_hit"
   end
 
+  @tag capture_log: true
   test_with_mock "rescues random database errors", EctoPSQLExtras, [:passthrough], [
     unused_indexes: fn(_repo, _opts) ->
       raise "random error"


### PR DESCRIPTION
This fixes an error that occurred when running `EctoPSQLExtras.diagnose/1` on Postgres 11.16:

```bash
10:49:56.541 [warning] Elixir.EctoPSQLExtras.DiagnoseLogic
** (MatchError) no match of right hand side value: :error
    (ecto_psql_extras 0.7.9) lib/ecto_psql_extras/diagnose_logic.ex:133: anonymous fn/1 in EctoPSQLExtras.DiagnoseLogic.null_indexes/1
    (elixir 1.14.2) lib/enum.ex:4197: Enum.filter_list/2
    (elixir 1.14.2) lib/enum.ex:4198: Enum.filter_list/2
    (ecto_psql_extras 0.7.9) lib/ecto_psql_extras/diagnose_logic.ex:132: EctoPSQLExtras.DiagnoseLogic.null_indexes/1
    (ecto_psql_extras 0.7.9) lib/ecto_psql_extras/diagnose_logic.ex:28: EctoPSQLExtras.DiagnoseLogic.run/1
    (ecto_psql_extras 0.7.9) lib/ecto_psql_extras.ex:121: EctoPSQLExtras.query/3
    (elixir 1.14.2) src/elixir.erl:309: anonymous fn/4 in :elixir.eval_external_handler/1
    (stdlib 4.1.1) erl_eval.erl:748: :erl_eval.do_apply/7
```

This was caused by `EctoPSQLExtras.null_indexes/2` returning the following row:

```elixir
[465344, "line_item_corrections_line_item_id_index", "1424 kB", true, "line_item_id", "    .07%", "972 bytes"]
```

Note the ` "    .07%"`.

`format_value/1` also failed because for some reason the tuple `{string, :string}` did not contain a string but an integer (`465344`).

