### PR TITLE
Update viable postgrex versions to include 0.17.X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,12 +126,12 @@ jobs:
         run: |
           sleep 4 # wait pg
           mix test --include distribution
-      - name: Install postgrex 0.16 (except on elixir 1.7.4)
+      - name: Install postgrex 0.17 (except on elixir 1.7.4)
         if: matrix.pair.elixir != '1.7.4'
         run: |
           mix deps.unlock --all
           mix deps.update postgrex
-      - name: Run tests for PG 11/postgrex 0.16 (0.15 on elixir 1.7.4)
+      - name: Run tests for PG 11/postgrex 0.17 (0.15 on elixir 1.7.4)
         env:
           PG_VERSION: 11
           POSTGRES_HOST: localhost
@@ -141,7 +141,7 @@ jobs:
         run: |
           sleep 4 # wait pg
           mix test --include distribution
-      - name: Run tests for PG 12/postgrex 0.16 (0.15 on elixir 1.7.4)
+      - name: Run tests for PG 12/postgrex 0.17 (0.15 on elixir 1.7.4)
         env:
           PG_VERSION: 12
           POSTGRES_HOST: localhost
@@ -151,7 +151,7 @@ jobs:
         run: |
           sleep 4 # wait pg
           mix test --include distribution
-      - name: Run tests for PG 13/postgrex 0.16 (0.15 on elixir 1.7.4)
+      - name: Run tests for PG 13/postgrex 0.17 (0.15 on elixir 1.7.4)
         env:
           PG_VERSION: 13
           POSTGRES_HOST: localhost
@@ -161,7 +161,7 @@ jobs:
         run: |
           sleep 4 # wait pg
           mix test --include distribution
-      - name: Run tests for PG 14/postgrex 0.16 (0.15 on elixir 1.7.4)
+      - name: Run tests for PG 14/postgrex 0.17 (0.15 on elixir 1.7.4)
         env:
           PG_VERSION: 14
           POSTGRES_HOST: localhost
@@ -171,7 +171,7 @@ jobs:
         run: |
           sleep 4 # wait pg
           mix test --include distribution
-      - name: Run tests for PG 15/postgrex 0.16 (0.15 on elixir 1.7.4)
+      - name: Run tests for PG 15/postgrex 0.17 (0.15 on elixir 1.7.4)
         env:
           PG_VERSION: 15
           POSTGRES_HOST: localhost

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule EctoPSQLExtras.Mixfile do
     [
       {:table_rex, "~> 3.1.1"},
       {:ecto_sql, "~> 3.4"},
-      {:postgrex, "~> 0.15.7 or ~> 0.16.0 or ~> 0.17.0"},
+      {:postgrex, "~> 0.15.7 or ~> 0.17.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:mock, "~> 0.3.0", only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule EctoPSQLExtras.Mixfile do
     [
       {:table_rex, "~> 3.1.1"},
       {:ecto_sql, "~> 3.4"},
-      {:postgrex, "~> 0.15.7 or ~> 0.16.0"},
+      {:postgrex, "~> 0.15.7 or ~> 0.16.0 or ~> 0.17.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:mock, "~> 0.3.0", only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule EctoPSQLExtras.Mixfile do
     [
       {:table_rex, "~> 3.1.1"},
       {:ecto_sql, "~> 3.4"},
-      {:postgrex, "~> 0.15.7 or ~> 0.17.0"},
+      {:postgrex, "~> 0.15.7 or ~> 0.16.0 or ~> 0.17.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:mock, "~> 0.3.0", only: :test}
     ]


### PR DESCRIPTION
* enables usage of the postgrex 0.17 minor series
  - https://github.com/elixir-ecto/postgrex/blob/master/CHANGELOG.md#v0170-2023-04-10