### PR TITLE
fix extension name in message

### DIFF
--- a/lib/ecto_psql_extras/diagnose_logic.ex
+++ b/lib/ecto_psql_extras/diagnose_logic.ex
@@ -214,7 +214,7 @@ defmodule EctoPSQLExtras.DiagnoseLogic do
     if EctoPSQLExtras.ssl_info_enabled(repo) do
       ssl_used_data(repo)
     else
-      [false, "ssl_used", "Cannot check connection status because 'ssl_info' extension is not enabled."]
+      [false, "ssl_used", "Cannot check connection status because 'sslinfo' extension is not enabled."]
     end
   end
 


### PR DESCRIPTION
Just a small fix for a message. The extension is called `sslinfo`, not `ssl_info`. See https://www.postgresql.org/docs/current/sslinfo.html.