### PR TITLE
Remove unused Escript config

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,6 @@ defmodule EctoPSQLExtras.Mixfile do
       version: @version,
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
-      escript: [main_module: EctoPSQLExtras],
       description: description(),
       deps: deps(),
       package: package(),


### PR DESCRIPTION
```sh
$ mix escript.build
Generated ecto_psql_extras app
Generated escript ecto_psql_extras with MIX_ENV=dev
warning: EctoPSQLExtras.main/1 is undefined or private
  /home/runner/work/elixir/elixir/lib/mix/lib/mix/tasks/escript.build.ex:396: :ecto_psql_extras_escript.main/1
```