### PR TITLE
Update Elixir and table_rex versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         include:
           - pair:
+              elixir: 1.16
+              otp: 26
+          - pair:
               elixir: 1.15
               otp: 26
           - pair:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.2-otp-26
+elixir 1.16.0-otp-26
 erlang 26.0.2

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule EctoPSQLExtras.Mixfile do
 
   def deps do
     [
-      {:table_rex, "~> 3.1.1"},
+      {:table_rex, "~> 3.1.1 or ~> 4.0.0"},
       {:ecto_sql, "~> 3.7"},
       {:postgrex, "~> 0.16.0 or ~> 0.17.0"},
       {:ex_doc, ">= 0.30.0", only: :dev, runtime: false},


### PR DESCRIPTION
Changes
 
- Update Elixir version to 1.16.0-otp-26 that contains latest compilation checks
- Relax table_rex version to support latest version