### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/ecto_psql_extras.ex
+++ b/lib/ecto_psql_extras.ex
@@ -123,18 +123,18 @@ defmodule EctoPSQLExtras do
     query_module = Map.fetch!(queries(repo), :diagnose)
     result = EctoPSQLExtras.DiagnoseLogic.run(repo)
 
-    opts = prepare_opts(opts, query_module.info[:default_args])
+    opts = prepare_opts(opts, query_module.info()[:default_args])
 
     format(
       Keyword.fetch!(opts, :format),
-      query_module.info,
+      query_module.info(),
       result
     )
   end
 
   def query(name, repo, opts) do
     query_module = Map.fetch!(queries(repo), name)
-    opts = prepare_opts(opts, query_module.info[:default_args])
+    opts = prepare_opts(opts, query_module.info()[:default_args])
 
     result =
       query!(
@@ -145,7 +145,7 @@ defmodule EctoPSQLExtras do
 
     format(
       Keyword.fetch!(opts, :format),
-      query_module.info,
+      query_module.info(),
       result
     )
   end


### PR DESCRIPTION
Hi!

We recently upgraded to Elixir 1.17.3 and got this deprecation warning. It seemed like an easy fix, so I went ahead and did it. I'm not sure this covers all usages within the project, but it stopped appearing for me at least.

![image](https://github.com/user-attachments/assets/62955516-1f54-43c1-882c-d164648f69e9)

Thanks for maintaining this lib, it helps out a lot :slightly_smiling_face: 