### PR TITLE
Also support Durations

### DIFF
--- a/lib/ecto_psql_extras.ex
+++ b/lib/ecto_psql_extras.ex
@@ -399,7 +399,7 @@ defmodule EctoPSQLExtras do
   end
 
   @doc false
-  def format_value({%struct{} = value, _}) when struct in [Decimal, Postgrex.Interval],
+  def format_value({%struct{} = value, _}) when struct in [Decimal, Duration, Postgrex.Interval],
     do: struct.to_string(value)
 
   def format_value({nil, _}), do: ""


### PR DESCRIPTION
In Postgrex v0.19, users can choose to emit
Elixir's new durations structs instead of
Postgrex.Interval, so let's convert them too.

This will require Elixir v1.18+ to work.