### PR TITLE
Relax `table_rex` version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule EctoPSQLExtras.Mixfile do
 
   def deps do
     [
-      {:table_rex, "~> 3.1.1 or ~> 4.0.0"},
+      {:table_rex, "~> 3.1.1 or ~> 4.0"},
       {:ecto_sql, "~> 3.7"},
       {:postgrex, "> 0.16.0"},
       {:ex_doc, ">= 0.30.0", only: :dev, runtime: false},


### PR DESCRIPTION
`:table_rex` updated in preparation for Elixir v1.19 and we can not update it due to being pinned out to the patch.

https://github.com/djm/table_rex